### PR TITLE
use export.subject.code unless only `dicom.fields.PatientID.replace-w…

### DIFF
--- a/deid_export/deid_template.py
+++ b/deid_export/deid_template.py
@@ -115,10 +115,15 @@ def validate(deid_template_path,
             df[new_subject_code_col] = df['dicom.fields.PatientID.replace-with']
         else:
             raise ValueError(f'columns {new_subject_code_col} is missing from dataframe')
+    elif (new_subject_code_col in df) and 'dicom.fields.PatientID.replace-with' in df:
+        logger.warning(
+            f'Both {new_subject_code_col} and dicom.fields.PatientID.replace-with are defined in dataframe. '
+            f'{new_subject_code_col} will be used for subject codes and dicom.fields.PatientID.replace-with '
+            'will be used for DICOM PatientID'
+        )
+
     if new_subject_code_col != DEFAULT_NEW_SUBJECT_CODE_COL:
         df[DEFAULT_NEW_SUBJECT_CODE_COL] = df[new_subject_code_col]
-    if 'dicom.fields.PatientID.replace-with' in df:
-        df['dicom.fields.PatientID.replace-with'] = df[new_subject_code_col]
 
     for c in required_cols:
         if c not in df:

--- a/deid_export/deid_template.py
+++ b/deid_export/deid_template.py
@@ -107,11 +107,19 @@ def validate(deid_template_path,
         deid_template = load(fid, Loader=Loader)
 
     df = pd.read_csv(csv_path, dtype=str)
-    if new_subject_code_col != DEFAULT_NEW_SUBJECT_CODE_COL:
-        if new_subject_code_col not in df:
-            raise ValueError(f'columns {new_subject_code_col} is missing from dataframe')
+    if new_subject_code_col not in df:
+        if 'dicom.fields.PatientID.replace-with' in df:
+            if not df['dicom.fields.PatientID.replace-with'].is_unique:
+                raise ValueError('"dicom.fields.PatientID.replace-with" is not unique in dataframe')
+
+            df[new_subject_code_col] = df['dicom.fields.PatientID.replace-with']
         else:
-            df[DEFAULT_NEW_SUBJECT_CODE_COL] = df[new_subject_code_col]
+            raise ValueError(f'columns {new_subject_code_col} is missing from dataframe')
+    if new_subject_code_col != DEFAULT_NEW_SUBJECT_CODE_COL:
+        df[DEFAULT_NEW_SUBJECT_CODE_COL] = df[new_subject_code_col]
+    if 'dicom.fields.PatientID.replace-with' in df:
+        df['dicom.fields.PatientID.replace-with'] = df[new_subject_code_col]
+
     for c in required_cols:
         if c not in df:
             raise ValueError(f'columns {c} is missing from dataframe')

--- a/grp13_container_export/README.md
+++ b/grp13_container_export/README.md
@@ -158,23 +158,26 @@ be the same for all subjects.
 * subject.code can be modified by including an export.subject.code
 column in subject_csv that contains unique values to be applied to 
 subjects in the destination project.
-* **NOTE: If you would also like to 
-change the value of the DICOM header PatientID, you must provide a 
-matching `dicom.fields.PatientID.replace-with` column** 
-* Conversely, `dicom.fields.PatientID.replace-with` will not modify 
-subject.code, a corresponding `export.subject.code` column must also 
-be provided to modify the subject.code values
+* **NOTE: If you provide an `export.subject.code` column, PatientID in 
+the DICOM headers will be set to the value in `export.subject.code` 
+for each subject. If you provide a `dicom.fields.PatientID.replace-with` 
+column alongside the `export.subject.code` column, 
+`dicom.fields.PatientID.replace-with` will be ignored** 
+* Conversely, if  `dicom.fields.PatientID.replace-with` is provided 
+without `export.subject.code`, `dicom.fields.PatientID.replace-with` 
+will be used to set PatientID in the DICOM headers and the new subject 
+codes.
 
 Let's walk through an example pairing of subject_csv and deid_template
 to illustrate. 
 
 The following table represents subject_csv (../tests/data/example-csv-mapping.csv):
 
-|subject.code|dicom.date-increment|export.subject.code|dicom.fields.PatientID.replace-with|dicom.fields.PatientBirthDate.remove|
-|------------|--------------------|-------------------|-----------------------------------|------------------------------------|
-|001         |-15                 |Patient_IDA        |IDA                                |false                               |
-|002         |-20                 |Patient_IDB        |IDB                                |true                                |
-|003         |-30                 |Patient_IDC        |IDC                                |true                                |
+|subject.code|dicom.date-increment|export.subject.code|dicom.fields.PatientBirthDate.remove|
+|------------|--------------------|-------------------|------------------------------------|
+|001         |-15                 |Patient_IDA        |false                               |
+|002         |-20                 |Patient_IDB        |true                                |
+|003         |-30                 |Patient_IDC        |true                                |
 
 The deid_template:
 ``` yaml
@@ -188,7 +191,7 @@ dicom:
       # remove can be any boolean since dicom.fields.PatientBirthDate.remove is defined in example-csv-mapping.csv
       remove: true
     - name: PatientID
-      # replace-with can be any string value since dicom.fields.PatientID.replace-with defined in example-csv-mapping.csv
+      # replace-with can be any string value since export.subject.code is defined in example-csv-mapping.csv
       replace-with: FLYWHEEL
 export:
   session:

--- a/grp13_container_export/README.md
+++ b/grp13_container_export/README.md
@@ -158,26 +158,24 @@ be the same for all subjects.
 * subject.code can be modified by including an export.subject.code
 column in subject_csv that contains unique values to be applied to 
 subjects in the destination project.
-* **NOTE: If you provide an `export.subject.code` column, PatientID in 
-the DICOM headers will be set to the value in `export.subject.code` 
-for each subject. If you provide a `dicom.fields.PatientID.replace-with` 
-column alongside the `export.subject.code` column, 
-`dicom.fields.PatientID.replace-with` will be ignored** 
-* Conversely, if  `dicom.fields.PatientID.replace-with` is provided 
-without `export.subject.code`, `dicom.fields.PatientID.replace-with` 
-will be used to set PatientID in the DICOM headers and the new subject 
-codes.
+* **NOTE: If `dicom.fields.PatientID.replace-with` is provided without 
+`export.subject.code`, `dicom.fields.PatientID.replace-with` will be 
+used to set subject.code for destination subjects. If 
+`export.subject.code` is provided, then it `export.subject.code` will be 
+used to set subject.code for destination subjects. 
+`dicom.fields.PatientID.replace-with` is required to set PatientID in
+DICOM files on a subject-to-subject basis** 
 
 Let's walk through an example pairing of subject_csv and deid_template
 to illustrate. 
 
 The following table represents subject_csv (../tests/data/example-csv-mapping.csv):
 
-|subject.code|dicom.date-increment|export.subject.code|dicom.fields.PatientBirthDate.remove|
-|------------|--------------------|-------------------|------------------------------------|
-|001         |-15                 |Patient_IDA        |false                               |
-|002         |-20                 |Patient_IDB        |true                                |
-|003         |-30                 |Patient_IDC        |true                                |
+|subject.code|dicom.date-increment|dicom.fields.PatientID.replace-with|dicom.fields.PatientBirthDate.remove|
+|------------|--------------------|-----------------------------------|------------------------------------|
+|001         |-15                 |Patient_IDA                        |false                               |
+|002         |-20                 |Patient_IDB                        |true                                |
+|003         |-30                 |Patient_IDC                        |true                                |
 
 The deid_template:
 ``` yaml
@@ -191,7 +189,7 @@ dicom:
       # remove can be any boolean since dicom.fields.PatientBirthDate.remove is defined in example-csv-mapping.csv
       remove: true
     - name: PatientID
-      # replace-with can be any string value since export.subject.code is defined in example-csv-mapping.csv
+      # replace-with can be any string value since dicom.fields.PatientID.replace-with is defined in example-csv-mapping.csv
       replace-with: FLYWHEEL
 export:
   session:
@@ -202,7 +200,7 @@ export:
         - operator
         - weight
   subject:
-    # code can be any string value since export.subject.code is defined in example-csv-mapping.csv
+    # code can be any string value since dicom.fields.PatientID.replace-with is defined in example-csv-mapping.csv
     code: FLYWHEEL
     whitelist:
       info:


### PR DESCRIPTION
…ith is provided.

The template still needs to define both, but this effectively prohibits diverging subject.code and PatientID