### PR TITLE
ENH: Download dicom type files regardless of extension [GEAR-347]

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ v = {editable = true,version = "*"}
 
 [packages]
 flywheel-sdk = "~=11.0"
-flywheel-migration = {editable = true,git = "https://gitlab.com/flywheel-io/public/migration-toolkit.git",ref = "18ef68eda8335e29d916842e01e74941a57e2d95"}
+flywheel-migration = {editable = true,git = "https://gitlab.com/flywheel-io/public/migration-toolkit.git",ref = "e63d8b0086ddfe6ae5d53c22e5606b17b4f22509"}
 pyaml = "*"
 joblib = "*"
 pandas = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ v = {editable = true,version = "*"}
 
 [packages]
 flywheel-sdk = "~=11.0"
-flywheel-migration = {editable = true,git = "https://gitlab.com/flywheel-io/public/migration-toolkit.git",ref = "ac8a7c9222f8cab2ceb8e922ab21abb35e4d0423"}
+flywheel-migration = {editable = true,git = "https://gitlab.com/flywheel-io/public/migration-toolkit.git",ref = "b72166f71d74592c703e592e9bb68d75929b9a07"}
 pyaml = "*"
 joblib = "*"
 pandas = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ v = {editable = true,version = "*"}
 
 [packages]
 flywheel-sdk = "~=11.0"
-flywheel-migration = {editable = true,git = "https://gitlab.com/flywheel-io/public/migration-toolkit.git",ref = "b72166f71d74592c703e592e9bb68d75929b9a07"}
+flywheel-migration = {editable = true,git = "https://gitlab.com/flywheel-io/public/migration-toolkit.git",ref = "18ef68eda8335e29d916842e01e74941a57e2d95"}
 pyaml = "*"
 joblib = "*"
 pandas = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f89567ddce86859ebe3058954bc386ed4fe17775c3f171de4788723943c25d67"
+            "sha256": "f96dad92b097d08175c6c57b7536c1c56765d774f76f3e692bef2bc169daf508"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -47,11 +47,11 @@
         "flywheel-migration": {
             "editable": true,
             "git": "https://gitlab.com/flywheel-io/public/migration-toolkit.git",
-            "ref": "b72166f71d74592c703e592e9bb68d75929b9a07"
+            "ref": "18ef68eda8335e29d916842e01e74941a57e2d95"
         },
         "flywheel-sdk": {
             "hashes": [
-            	"sha256:9414428920d11a84fef369bb8757a32d6f2eee00e8b59773ce5740013f87d22f"
+                "sha256:9414428920d11a84fef369bb8757a32d6f2eee00e8b59773ce5740013f87d22f"
             ],
             "index": "pypi",
             "version": "==11.2.5"
@@ -442,14 +442,6 @@
             ],
             "version": "==2.9"
         },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:298a914c82144c6b3b06c568a8973b89ad2176685f43cd1ea9ba968307300fa9",
-                "sha256:dfc83688553a91a786c6c91eeb5f3b1d31f24d71877bbd94ecbf5484e57690a2"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.5.2"
-        },
         "isort": {
             "hashes": [
                 "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
@@ -655,7 +647,6 @@
                 "sha256:d853840cde15a1adacac4e00b129a55e3c5c524f4b0ac88935502dd59823823f"
             ],
             "version": "==1.5.5"
-
         },
         "six": {
             "hashes": [
@@ -702,7 +693,6 @@
                 "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
                 "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
             ],
-            "markers": "implementation_name == 'cpython' and python_version < '3.8'",
             "version": "==1.4.1"
         },
         "typing": {
@@ -754,14 +744,6 @@
                 "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
             ],
             "version": "==1.11.2"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==3.1.0"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f96dad92b097d08175c6c57b7536c1c56765d774f76f3e692bef2bc169daf508"
+            "sha256": "ca21cd321dd25734f3a271fbcca28da8532c0632cec93d075bcb6bb8de7e5c69"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -47,7 +47,7 @@
         "flywheel-migration": {
             "editable": true,
             "git": "https://gitlab.com/flywheel-io/public/migration-toolkit.git",
-            "ref": "18ef68eda8335e29d916842e01e74941a57e2d95"
+            "ref": "e63d8b0086ddfe6ae5d53c22e5606b17b4f22509"
         },
         "flywheel-sdk": {
             "hashes": [
@@ -194,11 +194,11 @@
         },
         "pyaml": {
             "hashes": [
-                "sha256:9914879e6ac5cbf09b8cd5d3ba09e241ffcfd91c689cddc8d8b66a68c1c7e640",
-                "sha256:b077066dec4a1a834e376bd69b8b38677c69c62b270160cde35d76dc40ca9ec1"
+                "sha256:29a5c2a68660a799103d6949167bd6c7953d031449d08802386372de1db6ad71",
+                "sha256:67081749a82b72c45e5f7f812ee3a14a03b3f5c25ff36ec3b290514f8c4c4b99"
             ],
             "index": "pypi",
-            "version": "==20.3.1"
+            "version": "==20.4.0"
         },
         "pydicom": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8bf84c2df4159aae32479e607af8595cdb76b200ab4ce563729fbe7f1e447221"
+            "sha256": "f89567ddce86859ebe3058954bc386ed4fe17775c3f171de4788723943c25d67"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -47,14 +47,14 @@
         "flywheel-migration": {
             "editable": true,
             "git": "https://gitlab.com/flywheel-io/public/migration-toolkit.git",
-            "ref": "ac8a7c9222f8cab2ceb8e922ab21abb35e4d0423"
+            "ref": "b72166f71d74592c703e592e9bb68d75929b9a07"
         },
         "flywheel-sdk": {
             "hashes": [
-                "sha256:2d06fcfa996ea9db432de9a50f0af453e253cc5e4b6031bcca4d6f4b86cad69d"
+            	"sha256:9414428920d11a84fef369bb8757a32d6f2eee00e8b59773ce5740013f87d22f"
             ],
             "index": "pypi",
-            "version": "==11.2.3"
+            "version": "==11.2.5"
         },
         "fs": {
             "hashes": [
@@ -528,10 +528,10 @@
         },
         "pep517": {
             "hashes": [
-                "sha256:5ce351f3be71d01bb094d63253854b6139931fcaba8e2f380c02102136c51e40",
-                "sha256:882e2eeeffe39ccd6be6122d98300df18d80950cb5f449766d64149c94c5614a"
+                "sha256:576c480be81f3e1a70a16182c762311eb80d1f8a7b0d11971e5234967d7a342c",
+                "sha256:8e6199cf1288d48a0c44057f112acf18aa5ebabbf73faa242f598fbe145ba29e"
             ],
-            "version": "==0.8.1"
+            "version": "==0.8.2"
         },
         "pip-shims": {
             "hashes": [
@@ -651,10 +651,11 @@
         },
         "requirementslib": {
             "hashes": [
-                "sha256:0a22cdfd482de56478973ff0dd393fa4c76861d0cef3b259cd2e8a4a4bf40a15",
-                "sha256:470f788ddf370e8000dd25907ad6a19c9ca1f5e24e18e0bb3a4fe280cc20e31a"
+                "sha256:d29a49e72f8d3b0881c3af40215247cc84c178e6a1bb478182a6cfb51e17e9e6",
+                "sha256:d853840cde15a1adacac4e00b129a55e3c5c524f4b0ac88935502dd59823823f"
             ],
-            "version": "==1.5.4"
+            "version": "==1.5.5"
+
         },
         "six": {
             "hashes": [

--- a/deid_export/container_export.py
+++ b/deid_export/container_export.py
@@ -266,7 +266,7 @@ def initialize_container_file_export(fw_client, deid_profile, origin_container, 
     file_exporter_list = list()
     for container_file in origin_container.files:
 
-        if matches_file(deid_profile, container_file.name):
+        if matches_file(deid_profile, container_file):
             log.debug(
                 f'Initializing {origin_container.container_type} {origin_container.id} file {container_file.name}')
             tmp_file_exporter = FileExporter(fw_client=fw_client, origin_parent=origin_container,

--- a/grp13_container_export/manifest.json
+++ b/grp13_container_export/manifest.json
@@ -7,11 +7,11 @@
   "license": "Other",
   "source": "https://github.com/flywheel-apps/GRP-13",
   "url": "https://github.com/flywheel-apps/GRP-13/blob/master/grp13_container_export/README.md",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "custom": {
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/grp-13:2.0.0"
+      "image": "flywheel/grp-13:2.1.0"
     }
   },
   "inputs": {

--- a/tests/data/test_dicom_profile.yaml
+++ b/tests/data/test_dicom_profile.yaml
@@ -1,0 +1,73 @@
+dicom:
+  file-filter:
+    - "*"
+  filenames:
+    - output: '{Modality}_{SOPInstanceUID}.dcm'
+      input-regex: '.*.dcm.*'
+  fields:
+    - name: PatientID
+      replace-with: 'FLYWHEEL'
+
+zip:
+  filenames:
+    - output: '{SeriesDescription}_{SeriesNumber}.dcm.zip'
+      input-regex: '^.*\.zip$'
+  hash-subdirectories: true
+  fields:
+    - name: comment
+      replace-with: 'FLYWHEEL'
+
+jpg:
+  filenames:
+    - output: '{name_value}.jpg'
+      input-regex: '(?P<name_value>.*)\.jpg$'
+  date-increment: -17
+  remove-gps: True
+  fields:
+  - name: DateTime
+    increment-datetime: true
+  - name: Artist
+    remove: true
+  - name: DateTimeOriginal
+    increment-datetime: true
+  - name: DateTimeDigitized
+    increment-datetime: true
+  - name: CameraOwnerName
+    replace-with: 'REDACTED'
+
+png:
+  filenames:
+    - output: '{name_value}.png'
+      input-regex: '(?P<name_value>.*)\.png'
+  remove-private-chunks: True
+  fields:
+    - name: tEXt
+      remove: true
+    - name: eXIf
+      remove: true
+
+tiff:
+  filenames:
+    - output: '{DateTime}_{name_value}.tiff'
+      input-regex: '(?P<name_value>.*)\.tiff'
+  date-increment: -17
+  remove-private-tags: True
+  fields:
+    - name: DateTime
+      increment-datetime: true
+    - name: Software
+      remove: true
+    - name: Model
+      replace-with: 'REDACTED'
+
+xml:
+  date-increment: -17
+  fields:
+    - name: /Patient/Patient_Date_Of_Birth
+      replace-with: '1900-01-01'
+    - name: /Patient/Patient_Name
+      remove: true
+    - name: /Patient/SUBJECT_ID
+      hash: true
+    - name: /Patient/Visit/Scan/ScanTime
+      increment-datetime: true

--- a/tests/test_container_export.py
+++ b/tests/test_container_export.py
@@ -1,6 +1,7 @@
 import pytest
 from pathlib import Path
-from deid_export.container_export import hash_string, load_template_dict, quote_numeric_string
+from deid_export.container_export import hash_string, load_template_dict, quote_numeric_string, matches_file
+from deid_export.deid_template import load_deid_profile
 
 DATA_ROOT = Path(__file__).parent/'data'
 
@@ -40,3 +41,17 @@ def test_quote_numeric_string():
     in_str = '1.1.1'
     out_str = quote_numeric_string(in_str)
     assert out_str == '1.1.1'
+
+
+def test_matches_file():
+    template_dict = load_template_dict(str(DATA_ROOT / 'example-3-deid-profile.yaml'))
+    template_dict['dicom']['file-filter'] = []
+    deid_profile, _ = load_deid_profile(template_dict)
+    assert matches_file(deid_profile, {'type': 'dicom'})
+    assert matches_file(deid_profile, {'name': 'test.jpg'})
+    template_dict['jpg']['file-filter'] = []
+    deid_profile, _ = load_deid_profile(template_dict)
+    assert not matches_file(deid_profile, {'name': 'test.jpg'})
+    template_dict.pop('dicom')
+    deid_profile, _ = load_deid_profile(template_dict)
+    assert not matches_file(deid_profile, {'type': 'dicom', 'name': 'test.dcm'})


### PR DESCRIPTION
Files are now downloaded if they are type dicom and a dicom profile is provided in the deid template yaml in addition to if they match the file_filter of a profile. 

Some companion changes were also made to the migration-toolkit which can be viewed [here](https://gitlab.com/flywheel-io/public/migration-toolkit/-/compare/ac8a7c9222f8cab2ceb8e922ab21abb35e4d0423...18ef68eda8335e29d916842e01e74941a57e2d95). These changes allow downloaded files (or zip members) to be de-identified if they match the byte signature of the file profile or if they match the file_filter. 